### PR TITLE
add support for downloading

### DIFF
--- a/src/persistentActions.js
+++ b/src/persistentActions.js
@@ -1,5 +1,5 @@
 const { VariantType } = imports.gi.GLib;
-const { SimpleAction } = imports.gi.Gio;
+const { SimpleAction, AppInfo } = imports.gi.Gio;
 
 const instances = imports.instances;
 
@@ -24,4 +24,15 @@ this.PersistentActions = function PersistentActions({
     window.present();
   });
   application.add_action(showInstanceAction);
+
+  // https://gjs-docs.gnome.org/gio20~2.0_api/gio.simpleaction
+  const openURIAction = new SimpleAction({
+    name: "openURI",
+    parameter_type: VariantType.new("s"),
+  });
+  openURIAction.connect("activate", (self, parameters) => {
+    const path = parameters.unpack();
+    AppInfo.launch_default_for_uri(path, null);
+  });
+  application.add_action(openURIAction);
 };

--- a/src/tab.js
+++ b/src/tab.js
@@ -102,8 +102,13 @@ function TabLabel({ instance, settings, page }) {
 }
 
 this.TabPage = TabPage;
-function TabPage({ instance, window, onNotification }) {
-  const webView = buildWebView({ instance, window, onNotification });
+function TabPage({ instance, window, onNotification, application }) {
+  const webView = buildWebView({
+    instance,
+    window,
+    onNotification,
+    application,
+  });
   instance.page = webView;
   return webView;
 }

--- a/src/window.js
+++ b/src/window.js
@@ -134,6 +134,7 @@ this.Window = function Window({ application, profile, state }) {
 
   function buildInstance(instance) {
     const page = TabPage({
+      application,
       instance,
       window,
       onNotification,
@@ -227,7 +228,12 @@ this.Window = function Window({ application, profile, state }) {
       name: "",
     });
 
-    const webview = buildWebView({ onNotification, window, instance });
+    const webview = buildWebView({
+      application,
+      onNotification,
+      window,
+      instance,
+    });
 
     const previous = stack.get_child_by_name("new-tab");
     if (previous) previous.destroy();


### PR DESCRIPTION
If the download is an `http[s]` URI, cancel it and open it in the default application (browser)

Otherwise (eg [Firefox Send](https://send.firefox.com/)) open a dialog to choose where to save the file. It uses `GtkNativeChooserDialog` so there's no need for special permission on flatpak. It's ok not to have a download manager in that case because these are copied to the disk very fast. 

When the download fails or succeed, a notification is shown. In the later; the notification has 2 actions "Open file" and "Open folder", except on Flatpak where it's not currently possible without home directory permission, see https://github.com/flatpak/xdg-desktop-portal/issues/363

In the future Tangram will have its own download manager and opening the URI in a separate application won't be necessary.

![Screenshot from 2019-09-16 16-04-10](https://user-images.githubusercontent.com/19673/64965099-ab2f1c80-d89c-11e9-9369-d06aa7817540.png)

![notification](https://user-images.githubusercontent.com/19673/64965247-efbab800-d89c-11e9-8d03-d82f1295cb3c.png)

TODO:
* ~~report webkitgtk issue where `allow_overwrite(false) `does not seem to have any effect~~ https://bugs.webkit.org/show_bug.cgi?id=201868
* ~~test downloads without `suggested_filename`~~