### PR TITLE
Always open Google authentication in current tab

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1511,6 +1511,8 @@ const {
   WebView,
   ProcessModel,
   DownloadError,
+  // PolicyDecision,
+  // PolicyDecisionType,
 } = imports.gi.WebKit2;
 const {
   build_filenamev: build_filenamev$5,
@@ -1527,6 +1529,7 @@ const {
   ResourceLookupFlags,
   resources_open_stream,
 } = imports.gi.Gio;
+const { URI } = imports.gi.Soup;
 
 function buildWebView({
   instance,
@@ -1723,8 +1726,17 @@ function buildWebView({
   connect(webView, {
     // https://gjs-docs.gnome.org/webkit240~4.0_api/webkit2.webview#signal-create
     create(navigation_action) {
-      const uri = navigation_action.get_request().get_uri();
-      show_uri_on_window(window, uri, null);
+      const url = navigation_action.get_request().get_uri();
+
+      const host = new URI(url).get_host();
+      if (["accounts.google.com"].includes(host)) {
+        // Open URL in current tab
+        webView.load_uri(url);
+        return;
+      }
+
+      // Open URL in default browser
+      show_uri_on_window(window, url, null);
     },
 
     // https://gjs-docs.gnome.org/webkit240~4.0_api/webkit2.webview#signal-permission-request
@@ -1741,6 +1753,17 @@ function buildWebView({
       onNotification(notification, id);
       return true;
     },
+
+    // https://gjs-docs.gnome.org/webkit240~4.0_api/webkit2.webview#signal-decide-policy
+    // ["decide-policy"](decision, decision_type) {
+    //   // PolicyDecision.NAVIGATION_ACTION
+    //   // PolicyDecision.RESPONSE
+    //   if (decision === PolicyDecision.NEW_WINDOW_ACTION) {
+    //     log("new window");
+    //     return true;
+    //   }
+    //   return false;
+    // },
   });
 
   webView.instance_id = id;
@@ -1874,7 +1897,7 @@ const {
   Entry: Entry$2,
   //  CssProvider
 } = imports.gi.Gtk;
-const { URI } = imports.gi.Soup;
+const { URI: URI$1 } = imports.gi.Soup;
 
 function normalizeURL(str) {
   if (!str) return null;
@@ -1883,7 +1906,7 @@ function normalizeURL(str) {
     str = "http://" + str;
   }
 
-  const uri = new URI(str);
+  const uri = new URI$1(str);
   if (!uri) return null;
 
   // FIXME


### PR DESCRIPTION
The design of Tangram is to open "external" links into the default browser.
This is only true for `<a target="_blank">` for now and might extend to any link with a different origin in the future.

This design breaks SSO (Single Sign On) as described in #85 and #91

This PR is an attempt at solving the issue by always opening certain links (for now only `accounts.google.com`) into the current tab.

I'm not really satisfied with this solution as it requires maintaining a list of origins for SSO and will break with self-hosted solutions.

Any better ideas?