### PR TITLE
Enforce same-site navigation

### DIFF
--- a/src/hostnameUtils.js
+++ b/src/hostnameUtils.js
@@ -7,15 +7,20 @@ const { hostname_to_ascii } = imports.gi.GLib;
 
 // Implements https://web.dev/same-site-same-origin/
 function isSameSite(a, b) {
+  // uris
   a = new URI(a);
   b = new URI(b);
-
   if (!a || !b) return false;
 
-  // punycode
-  a = hostname_to_ascii(a.get_host());
-  b = hostname_to_ascii(b.get_host());
+  // hostnames
+  a = a.get_host();
+  b = b.get_host();
+  // example: about:blank
+  if (!a || !b) return a === b;
 
+  // punycode
+  a = hostname_to_ascii(a);
+  b = hostname_to_ascii(b);
   if (!a || !b) return false;
 
   try {

--- a/src/hostnameUtils.test.js
+++ b/src/hostnameUtils.test.js
@@ -26,11 +26,9 @@ assert.is(
   isSameSite("https://foo.ком.рус", "https://bar.xn--j1aef.xn--p1acf"),
   true,
 );
+assert.is(isSameSite("about:blank", "about:blank"), true);
 
 assert.is(isSameSite("https://foo", "https://bar"), false);
 assert.is(isSameSite("https://foo.github.io", "https://bar.github.io"), false);
 assert.is(isSameSite("https://foo.github.io", "https://github.io"), false);
 assert.is(isSameSite("https://foo.github.io", "https://github.io"), false);
-assert.is(isSameSite("some-invalid-url", "some-invalid-url"), false);
-assert.is(isSameSite("some-invalid-url", "some-other-invalid-url"), false);
-assert.is(isSameSite("https://", "https://"), false);


### PR DESCRIPTION
https://github.com/sonnyp/Tangram/pull/105 only implemented same site navigation for links that would normally open a new tab.

This enforces same-site navigation for regular links and navigation actions.

Basically what it means is that if you click on a link with a different domain as the current one - it will open in the external browser.