### PR TITLE
Use 'Whether' instead of incorrect 'Weither'

### DIFF
--- a/data/re.sonny.Tangram.gschema.xml
+++ b/data/re.sonny.Tangram.gschema.xml
@@ -38,7 +38,7 @@
     <key name="window-maximized" type="b">
       <default>false</default>
       <summary>Window maximized</summary>
-      <description>Weither the window is maximized</description>
+      <description>Whether the window is maximized</description>
     </key>
 
     <key name="instances" type="as">


### PR DESCRIPTION
The "I before E except after C" rule caught my attention here while working on the French translation. I don't think this word exists in English.

Whether (as defined as "Expressing a doubt or choice between alternatives" by the Oxford Dictionary) seems to work better here.

