### PR TITLE
Workaround not presenting window on notification click

### DIFF
--- a/src/Actions.js
+++ b/src/Actions.js
@@ -40,6 +40,9 @@ export default function Actions({ window, application, selectTab }) {
       selectTab(instance);
     }
 
+    // FIXME: temporary workaround
+    // Calling this twice to work around: https://gitlab.gnome.org/GNOME/gtk/-/issues/5239
+    window.present();
     window.present();
   });
   application.add_action(showInstanceAction);


### PR DESCRIPTION
This forces shell to show the "This window is ready" notification, when a notification is clicked.

fixes #232 